### PR TITLE
Update for new heuristic callback design

### DIFF
--- a/src/GLPKInterfaceMIP.jl
+++ b/src/GLPKInterfaceMIP.jl
@@ -234,7 +234,7 @@ function cbaddcut!(d::GLPKCallbackData, colidx::Vector, colcoef::Vector, sense::
 end
 
 function _initsolution!(d::GLPKCallbackData)
-    isempty(d) || return
+    isempty(d.sol) || return
     lp = GLPK.ios_get_prob(d.tree)
     n = GLPK.get_num_cols(lp)
     resize!(d.sol, n)
@@ -258,7 +258,7 @@ function cbaddsolution!(d::GLPKCallbackData)
         error("cbaddsolution! can only be called from within a heuristiccallback")
     _initsolution!(d)
     _fillsolution!(d)
-    GLPK.ios_heur_sol(d.tree, x)
+    GLPK.ios_heur_sol(d.tree, d.sol)
     fill!(d.sol, NaN)
 end
 


### PR DESCRIPTION
@IainNZ this is an alternative take on the new heuristic callback implementation, but I did not test it, can you do it?

The way this works is by keeping a solution vector, and signalling via NaNs which values are not initialized. This may an abuse of the meaning of NaN, but I thought it is safe. Another possibility is adding a bitmask (DataFrames style).

Note: the way it works now tries to mimic what you submitted in #8, in that after the solution is fed to the GLPK solver, it is "forgotten", i.e. one needs to call `cbsetsolutionvalue!` every time before using `cbaddsolution!`.
