### PR TITLE
0.4-dev fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.2
 GLPK 0.2.8
 MathProgBase 0.3.0 0.4.0-
+Compat 0.3.5

--- a/src/GLPKInterfaceMIP.jl
+++ b/src/GLPKInterfaceMIP.jl
@@ -4,6 +4,8 @@ import GLPK
 importall MathProgBase.SolverInterface
 importall ..GLPKInterfaceBase
 
+using Compat
+
 export
     GLPKSolverMIP,
     GLPKCallbackData,
@@ -394,11 +396,11 @@ function setvartype!(lpm::GLPKMathProgModelMIP, vartype::Vector{Symbol})
     end
 end
 
-const vartype_map = [
+@compat const vartype_map = Dict(
     GLPK.CV => :Cont,
     GLPK.IV => :Int,
     GLPK.BV => :Bin
-]
+)
 
 function getvartype(lpm::GLPKMathProgModelMIP)
     lp = lpm.inner

--- a/src/GLPKMathProgInterface.jl
+++ b/src/GLPKMathProgInterface.jl
@@ -6,9 +6,9 @@ export
     GLPKSolverLP,
     GLPKSolverMIP
 
-include(joinpath(dirname(Base.source_path()), "GLPKInterfaceBase.jl"))
-include(joinpath(dirname(Base.source_path()), "GLPKInterfaceLP.jl"))
-include(joinpath(dirname(Base.source_path()), "GLPKInterfaceMIP.jl"))
+include("GLPKInterfaceBase.jl")
+include("GLPKInterfaceLP.jl")
+include("GLPKInterfaceMIP.jl")
 
 const GLPKSolverLP = GLPKInterfaceLP.GLPKSolverLP
 const GLPKSolverMIP = GLPKInterfaceMIP.GLPKSolverMIP

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,12 @@
 using GLPKMathProgInterface
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","linprog.jl"))
+const mathprogbase_test = joinpath(Pkg.dir("MathProgBase"), "test")
+
+include(joinpath(mathprogbase_test, "linprog.jl"))
 linprogtest(GLPKSolverLP())
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","linproginterface.jl"))
+include(joinpath(mathprogbase_test, "linproginterface.jl"))
 linprogsolvertest(GLPKSolverLP())
 
-include(joinpath(Pkg.dir("MathProgBase"),"test","mixintprog.jl"))
+include(joinpath(mathprogbase_test, "mixintprog.jl"))
 mixintprogtest(GLPKSolverMIP())


### PR DESCRIPTION
1. Fix deprecation warning about `Dict` constructor
2. Remove manual path construction for `include`
3. The change in `runtests.jl` is some left over for my local testing (in order to workaround https://github.com/JuliaLang/julia/issues/8679) and I think it doesn't hurt to keep.
