### PR TITLE
Allow invalid bounds with set..B!

### DIFF
--- a/src/GLPKInterfaceBase.jl
+++ b/src/GLPKInterfaceBase.jl
@@ -82,18 +82,24 @@ function loadproblem!(lpm::GLPKMathProgModel, A::AbstractMatrix, collb, colub, o
     end
 
     m > 0 && GLPK.add_rows(lp, m)
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for r = 1:m
         #println("  r=$r b=$(b[r])")
         l, u, t = getbounds(rowlb, rowub, r)
         GLPK.set_row_bnds(lp, r, t, l, u)
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 
     n > 0 && GLPK.add_cols(lp, n)
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for c = 1:n
         #println("  r=$r b=$(b[r])")
         l, u, t = getbounds(collb, colub, c)
         GLPK.set_col_bnds(lp, c, t, l, u)
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 
     if nonnull(obj)
         for c = 1:n
@@ -133,6 +139,8 @@ function setvarLB!(lpm::GLPKMathProgModel, collb)
     if nonnull(collb) && length(collb) != n
         error("invalid size of collb")
     end
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for c = 1:n
         u = GLPK.get_col_ub(lp, c)
         if u >= realmax(Float64)
@@ -157,6 +165,7 @@ function setvarLB!(lpm::GLPKMathProgModel, collb)
             end
         end
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 end
 
 function getvarUB(lpm::GLPKMathProgModel)
@@ -179,6 +188,8 @@ function setvarUB!(lpm::GLPKMathProgModel, colub)
     if nonnull(colub) && length(colub) != n
         error("invalid size of colub")
     end
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for c = 1:n
         l = GLPK.get_col_lb(lp, c)
         if l <= -realmax(Float64)
@@ -203,6 +214,7 @@ function setvarUB!(lpm::GLPKMathProgModel, colub)
             end
         end
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 end
 
 function getconstrLB(lpm::GLPKMathProgModel)
@@ -225,6 +237,8 @@ function setconstrLB!(lpm::GLPKMathProgModel, rowlb)
     if nonnull(rowlb) && length(rowlb) != m
         error("invalid size of rowlb")
     end
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for r = 1:m
         u = GLPK.get_row_ub(lp, r)
         if u >= realmax(Float64)
@@ -249,6 +263,7 @@ function setconstrLB!(lpm::GLPKMathProgModel, rowlb)
             end
         end
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 end
 
 function getconstrUB(lpm::GLPKMathProgModel)
@@ -271,6 +286,8 @@ function setconstrUB!(lpm::GLPKMathProgModel, rowub)
     if nonnull(rowub) && length(rowub) != m
         error("invalid size of rowub")
     end
+    prev_preemptive_check = GLPK.jl_get_preemptive_check()
+    GLPK.jl_set_preemptive_check(false)
     for r = 1:m
         l = GLPK.get_row_lb(lp, r)
         if l <= -realmax(Float64)
@@ -295,6 +312,7 @@ function setconstrUB!(lpm::GLPKMathProgModel, rowub)
             end
         end
     end
+    GLPK.jl_set_preemptive_check(prev_preemptive_check)
 end
 
 function getconstrmatrix(lpm::GLPKMathProgModel)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using GLPKMathProgInterface, Base.Test
 
 include("params.jl")
+include("setbounds.jl")
 include("mathprog.jl")

--- a/test/setbounds.jl
+++ b/test/setbounds.jl
@@ -3,14 +3,28 @@ using GLPKMathProgInterface, MathProgBase, Base.Test
 @testset "Invalid bounds" begin
     solver = GLPKSolverLP()
     m = MathProgBase.LinearQuadraticModel(solver)
+    function testmodel(sense)
+        MathProgBase.optimize!(m)
+        @test MathProgBase.status(m) == :Infeasible
+        @test MathProgBase.getobjval(m) == (sense == :Min ? Inf : -Inf)
+        @test MathProgBase.getinfeasibilityray(m) == zeros(1)
+        @test_throws ErrorException MathProgBase.getsolution(m)
+        @test_throws ErrorException MathProgBase.getconstrsolution(m)
+        @test_throws ErrorException MathProgBase.getreducedcosts(m)
+        @test_throws ErrorException MathProgBase.getconstrduals(m)
+        @test_throws ErrorException MathProgBase.getunboundedray(m)
+    end
     # invalid variable bounds
-    @test_throws GLPK.GLPKError MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, -1], [0, 0], [0], [1], :Min)
+    MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, -1], [0, 0], [0], [1], :Min)
+    testmodel(:Min)
     # invalid constraint bounds
-    @test_throws GLPK.GLPKError MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, 1], [0, 0], [0], [-1], :Min)
+    MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, 1], [0, 0], [0], [-1], :Max)
+    testmodel(:Max)
     MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, 1], [0, 0], [0], [1], :Min)
     # Those do not throws errors since the invalid bounds may be temporary
     MathProgBase.setvarLB!(m, [2, 0])
     MathProgBase.setvarUB!(m, [1, -1])
     MathProgBase.setconstrLB!(m, [2])
     MathProgBase.setconstrUB!(m, [-1])
+    testmodel(:Min)
 end

--- a/test/setbounds.jl
+++ b/test/setbounds.jl
@@ -1,0 +1,16 @@
+using GLPKMathProgInterface, MathProgBase, Base.Test
+
+@testset "Invalid bounds" begin
+    solver = GLPKSolverLP()
+    m = MathProgBase.LinearQuadraticModel(solver)
+    # invalid variable bounds
+    @test_throws GLPK.GLPKError MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, -1], [0, 0], [0], [1], :Min)
+    # invalid constraint bounds
+    @test_throws GLPK.GLPKError MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, 1], [0, 0], [0], [-1], :Min)
+    MathProgBase.loadproblem!(m, [1 0], [0, 0], [1, 1], [0, 0], [0], [1], :Min)
+    # Those do not throws errors since the invalid bounds may be temporary
+    MathProgBase.setvarLB!(m, [2, 0])
+    MathProgBase.setvarUB!(m, [1, -1])
+    MathProgBase.setconstrLB!(m, [2])
+    MathProgBase.setconstrUB!(m, [-1])
+end


### PR DESCRIPTION
Related to https://github.com/JuliaOpt/MathProgBase.jl/issues/142
When updating a range constraints of range variables bounds using `set[var|row][L|U]B!`, it may happen that the upper bound is momentarily invalid. Disabling the check solves the issue.
Should we add a check at `optimize!` ?