### PR TITLE
Update Compat lower bound

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 GLPK 0.2.8
 MathProgBase 0.5 0.8
-Compat 0.66
+Compat 1.1.0


### PR DESCRIPTION
The codes uses `floatmax` which was added in Compat 1.1.0.